### PR TITLE
Fix stray quote in sort validation

### DIFF
--- a/src/main/scala/software/altitude/core/util/Query.scala
+++ b/src/main/scala/software/altitude/core/util/Query.scala
@@ -70,7 +70,7 @@ class Query(val params: Map[String, Any] = Map(), val rpp: Int = 0, val page: In
   if (page < 1) throw new IllegalArgumentException(s"Invalid page value: $page")
 
   if (sort.size > 1) {
-    throw new IllegalArgumentException("Only one sort currently supported'")
+    throw new IllegalArgumentException("Only one sort currently supported")
   }
 
   val isSorted: Boolean = sort.nonEmpty

--- a/src/main/scala/software/altitude/core/util/SearchQuery.scala
+++ b/src/main/scala/software/altitude/core/util/SearchQuery.scala
@@ -30,7 +30,7 @@ class SearchQuery(
   }
 
   if (searchSort.size > 1) {
-    throw new IllegalArgumentException("Only one sort currently supported'")
+    throw new IllegalArgumentException("Only one sort currently supported")
   }
 
   val hasMetadataFilters: Boolean = metadataFilters.nonEmpty


### PR DESCRIPTION
## Summary
- remove stray quote from Query sort validation error
- remove stray quote from SearchQuery sort validation error

## Testing
- `sbt compile` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_6896fc1bc7fc8329a90adad75f0a0792